### PR TITLE
Fix for days containing no segments

### DIFF
--- a/lib/output/DayOneExport.js
+++ b/lib/output/DayOneExport.js
@@ -50,6 +50,8 @@ function DayOneExport(options) {
 DayOneExport.prototype = Object.create(DefaultPlugin.prototype);
 
 DayOneExport.prototype.exportDay = function exportDay(day, cb) {
+    if(day.segments == null) return;
+
     var that = this;
 
     // Find default iCloud DayOne directory


### PR DESCRIPTION
A forEach call on the null `days.segments` would result in a TypeError.

Now we just skip the day entirely.
