### PR TITLE
Fix yesterday option.

### DIFF
--- a/lib/Elizabeth.js
+++ b/lib/Elizabeth.js
@@ -277,8 +277,8 @@ function _getDateRangeFromParameters(range, params) {
 	}
 
 	if(params.yesterday) {
-		range.start = moment().subtract('days', 1);
-		range.end = moment();
+		range.start = moment().subtract('days', 2);
+		range.end = moment().subtract('days', 1);
 	}
 
 	return range;


### PR DESCRIPTION
The `--yesterday` option used to import the current day instead of the
previous. This pr fixes that.
