### PR TITLE
Fix error if target folder is on a different partition/device

### DIFF
--- a/lib/output/DayOneExport.js
+++ b/lib/output/DayOneExport.js
@@ -198,7 +198,13 @@ DayOneExport.prototype.saveEntry = function saveEntry(date, text, mapfile, entry
 
         // Seems like we need to use jpgs, because DayOne for iPhone just
         // does not display .png files :/
-        fs.renameSync(mapfile, path.join(that.options.directory, 'photos', entry['UUID'] + '.jpg'));
+        var is = fs.createReadStream(mapfile);
+        var os = fs.createWriteStream(path.join(that.options.directory, 'photos', entry['UUID'] + '.jpg'));
+        is.pipe(os);
+        is.on('end', function()
+        {
+            fs.unlinkSync(mapfile);
+        });
 
         cb(null, date);
     });


### PR DESCRIPTION
Day One export failed with the following message if the target directory (in my case dropbox) was located at a different partition or device.

![ellieerror](https://f.cloud.github.com/assets/78763/2068334/ff9c697a-8d08-11e3-9520-6c8c69f1f73b.png)
