### PR TITLE
Added null check to prevent TypeError

### DIFF
--- a/lib/output/DayOneExport.js
+++ b/lib/output/DayOneExport.js
@@ -53,7 +53,7 @@ function DayOneExport(options) {
 DayOneExport.prototype = Object.create(DefaultPlugin.prototype);
 
 DayOneExport.prototype.exportDay = function exportDay(day, cb) {
-    if(day.segments == null) return;
+    if(day == null || day.segments == null) return;
 
     var that = this;
 


### PR DESCRIPTION
I got the following error when trying to import 365 days (the first ~10 days exported without problems): `TypeError: Cannot read property 'segments' of undefined`