### PR TITLE
updated resolution of google maps exporter

### DIFF
--- a/lib/output/GoogleMapExport.js
+++ b/lib/output/GoogleMapExport.js
@@ -72,7 +72,7 @@ GoogleMapExport.prototype.exportDay = function exportDay(day, cb) {
 	points = reduceLocations(points, 30);
 
 	var base_url = 'http://maps.googleapis.com/maps/api/staticmap?sensor=false&maptype=roadmap';
-	var url = base_url + '&format=' + this.options.format + '&size=' + this.options.size + '&scale=1' +
+	var url = base_url + '&format=' + this.options.format + '&size=' + this.options.size + '&scale=2' +
 	'&path=color:0x0000ff%7Cweight:5' + coordinates_to_string(points);
 
 	url = url + '&markers=color:blue%7Csize:normal' + coordinates_to_string(places);


### PR DESCRIPTION
Bumped up the Google Maps scale from 1 to 2 as outlined [here](https://developers.google.com/maps/documentation/static-maps/intro#scale_values).
